### PR TITLE
3.5.1 out of box fails, 3.6.2 works

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.1
+python-3.6.2


### PR DESCRIPTION
Otherwise you get this error:
```
remote: -----> Python app detected
remote: -----> Installing python-3.5.1
remote: -----> Installing pip
remote: -----> Installing requirements with pip
remote:        /app/tmp/buildpacks/779a8bbfbbe7e1b715476c0b23fc63a2103b3e4131eda558669aba8fb5e6e05682419376144189b29beb5dee6d7626b4d3385edb0954bffea6c67d8cf622fd51/bin/steps/pip-install: line 7: /app/.heroku/python/bin/pip: No such file or directory
remote:  !     Push rejected, failed to compile Python app.
```

The currently supported versions at the moment are listed here: https://devcenter.heroku.com/articles/python-runtimes
